### PR TITLE
Make the benchmark compile successfully by GCC

### DIFF
--- a/SIMDString.h
+++ b/SIMDString.h
@@ -801,7 +801,7 @@ public:
             return append(c);
         }
         replace(pos - m_data, 0, 1, c);
-        return m_data + pos;
+        return pos;
     }
 
     constexpr SIMDString& insert(const_iterator pos, std::initializer_list<value_type> ilist) {

--- a/benchmarks/benchmarks.h
+++ b/benchmarks/benchmarks.h
@@ -501,6 +501,7 @@ static void BM_Swap(benchmark::State& state)
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // This is where the benchmarks are programmatically registered .
+template <typename Str>
 void RegisterBenchmarks(const char* classname) {
     // buffer for formatting the benchmark name string into RegisterBenchmark
     char buffer[512];

--- a/benchmarks/main.cpp
+++ b/benchmarks/main.cpp
@@ -1,6 +1,6 @@
 //#define TEST_EASTL
 //#define TEST_FOLLY
-#define TEST_G3D_ALLOC
+//#define TEST_G3D_ALLOC
 
 
 #include "SIMDString.h"
@@ -19,7 +19,7 @@
 #endif
 
 
-int main(int argc, const char* argv[]) {
+int main(int argc, char* argv[]) {
     // __VA_ARGS_ is necessary because type templating messes up Macro argument parsing
 #   define REGISTER_CLASS_BENCHMARKS(...) RegisterBenchmarks<__VA_ARGS__>(#__VA_ARGS__)
 


### PR DESCRIPTION
The benchmark CANNOT be compiled successfully by either GCC (12.2) or Clang (14.0).

This PR makes the benchmark pass gcc and run successfully.

BTW, the SSO inline size of std::string in libstdc++ is 15 now (22 in libc++, maybe), 
so **the default SSO size of SIMDString in the benchmark is not fair to be compared with std::string**.

Also, the only use of SIMD in the whole project is a handwritten memcpy: this is strange, 
because memcpy in glibc, for example, is highly optimized (handwritten assembly with SSE2/AVX2 instructions), 
so I find it hard to believe that **such a very trivial toy memcpy could be more efficient**.

IMHO this project is more like an assignment from a random college student than a proven product in a company.