### PR TITLE
fix memory access overflows in starts/ends_with functions

### DIFF
--- a/SIMDString.h
+++ b/SIMDString.h
@@ -1223,28 +1223,29 @@ public:
     }
 
     constexpr bool starts_with(value_type c) const {
-        return *m_data == c;
+        return m_length > 0 && *m_data == c;
     }
 
     constexpr bool starts_with(const value_type* s) const {
-        return memcmp(s, m_data, ::strlen(s)) == 0;
+        size_type n = ::strlen(s);
+        return m_length >= n && memcmp(s, m_data, n) == 0;
     }
 
     constexpr bool starts_with(std::string_view sv) const {
-        return memcmp(sv.data(), m_data, sv.size()) == 0;
+        return m_length >= sv.size() && memcmp(sv.data(), m_data, sv.size()) == 0;
     }
 
     constexpr bool ends_with(value_type c) const {
-        return *(m_data + m_length - 1) == c;
+        return m_length > 0 && *(m_data + m_length - 1) == c;
     }
 
     constexpr bool ends_with(const value_type* s) const {
         size_type n = ::strlen(s);
-        return memcmp(s, m_data + m_length - n, n) == 0;
+        return m_length >= n && memcmp(s, m_data + m_length - n, n) == 0;
     }
 
     constexpr bool ends_with(std::string_view sv) const {
-        return memcmp(sv.data(), m_data + m_length - sv.size(), sv.size()) == 0;
+        return m_length >= sv.size() && memcmp(sv.data(), m_data + m_length - sv.size(), sv.size()) == 0;
     }
 
     constexpr SIMDString substr(size_type pos, size_type count = npos) const {


### PR DESCRIPTION
I have noticed some problems in the start/ends_with functions. So, here are their fixes.

It's hard to write good tests to reproduce these issues in tests, but here's one of the few easy ways to do it:

```
const char* s = "hello world";
EXPECT_FALSE(SIMDString(s + 6).ends_with("hello world"));
```

This test will fail without my PR.