### PR TITLE
Changed string_view conversion op to const and not-explicit

### DIFF
--- a/SIMDString.h
+++ b/SIMDString.h
@@ -916,7 +916,7 @@ public:
         return data()[m_length - 1];
     }
 
-    explicit constexpr inline operator std::basic_string_view<value_type>() {
+    constexpr inline operator std::basic_string_view<value_type>() const {
         return std::string_view(data(), m_length);
     }
 


### PR DESCRIPTION
As it is for std::string
VS2022 implementation:
![image](https://github.com/user-attachments/assets/5598198c-5b63-431b-aeb1-9aa31d36c116)
